### PR TITLE
More efficient handling of keywords 

### DIFF
--- a/flatlanders/keywords.py
+++ b/flatlanders/keywords.py
@@ -78,11 +78,9 @@ POLITICAL_WORDS = {
 
 
 POLITICIANS = {
-    # Independants
     "Ryan Domotor",
     "Greg Lawrence",
     "Nadine Wilson",
-    # Sask NDP
     "carla beck",
     "jennifer bowes",
     "Noor Burki",
@@ -90,14 +88,13 @@ POLITICIANS = {
     "Meara Conway",
     "Matt Love",
     "Vicki Mowat",
-    "Betty Nippi-Albright" "Betty Nippi",
+    "Betty Nippi-Albright", "Betty Nippi",
     "Erika Ritchie",
     "Nicole Sarauer",
     "Nathaniel Teed",
     "Doyle Vermette",
     "Trent Wotherspoon",
-    "Aleana Young"
-    # Sask Party
+    "Aleana Young",
     "Steven Bonk",
     "Terry Dennis",
     "Dustion Duncan",

--- a/flatlanders/labelers.py
+++ b/flatlanders/labelers.py
@@ -25,6 +25,7 @@ repo = client.com.atproto.repo.describe_repo({"repo": FEEDGEN_PUBLISHER_DID})
 did_doc = DidDocument.from_dict(repo.did_doc)
 client._base_url = f"{did_doc.get_pds_endpoint()}/xrpc"
 
+compiled_patterns = [re.compile(rf"\b{word}\b") for word in POLITICAL_CONTENT]
 
 def has_political_content(post: Post) -> bool:
     """Indicate if a post has political content.
@@ -36,7 +37,7 @@ def has_political_content(post: Post) -> bool:
         bool: True if text matches any of the political content keywords.
     """
     lower_text = post.text.lower()
-    return any([re.search(rf"\b{word}\b", lower_text) for word in POLITICAL_CONTENT])
+    return any(pattern.search(lower_text) for pattern in compiled_patterns)
 
 
 def raise_label_event(post: Post, label: str):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+asgiref==3.8.1
+atproto==0.0.54
+Django==5.1.1
+pytest==8.3.2
+python-dotenv==1.0.1


### PR DESCRIPTION
I fixed typos in the keywords sets and removed the comments within them (not Pythonic). 
In the flatlander_feed.py I put all the authors in a dictionary, so that it doesn’t have to check if the author is in the database for each post. Additionally, I precompiled the regex pattern so it isn’t generated for each post. I did the same thing for labelers.py. 